### PR TITLE
Replacing dask with `srun` and concurrent.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ ENV/
 # mypy
 .mypy_cache/
 workflow_config.json
+.distribute/*

--- a/config.yaml
+++ b/config.yaml
@@ -13,9 +13,13 @@ resources:
     walltime: "9-24:00:00"
     path_python_env: "/home/matheus.viana/anaconda3/envs/cvapipe/bin/python"
 
-mappoints:
+pca:
+    # Number of principal components to be calculated
+    number_of_pcs: 8
     # Number of map points along each principal component
-    nbins: 9
+    number_map_points: 9
+    # limits of x and y axies in the animated GIFs
+    plot_limits: [-150, 150, -80, 80]
 
 aggregation:
     # Shape space used to create aggregated images.
@@ -26,13 +30,10 @@ aggregation:
     aggregate_on: "DNA_MEM_PC"
 
 structures:
-    # Gene names of each tagged structure. These match
-    # the column structure_name in the manifest.
-
-    genes: ["FBL", "NPM1", "SON", "SMC1A", "HIST1H2BJ", "LMNB1", "NUP153", "SEC61B", "ATP2A2", "TOMM20", "SLC25A17", "RAB5A", "LAMP1",  "ST6GAL1", "CETN2", "TUBA1B", "AAVS1", "ACTB", "ACTN1", "MYH10", "GJA1", "TJP1", "DSP", "CTNNB1", "PXN"]
 
     # >> Results are going to be ordered according to
-    # this sequence.
+    # this sequence. These match the column structure_name
+    # in the manifest.
     genes: ["FBL", "NPM1", "SON", "SMC1A", "HIST1H2BJ", "LMNB1", "NUP153", "SEC61B", "ATP2A2", "TOMM20", "SLC25A17", "RAB5A", "LAMP1",  "ST6GAL1", "CETN2", "TUBA1B", "AAVS1", "ACTB", "ACTN1", "MYH10", "GJA1", "TJP1", "DSP", "CTNNB1", "PXN"]
     # Mapping between gene name and description
     desc:

--- a/config.yaml
+++ b/config.yaml
@@ -2,15 +2,16 @@ appName: cvapipe_analysis
 
 project:
     # Sufix to append to local_staging
-    name: "test"
+    name: "full"
 
 resources:
     # In case a (slurm) cluster is available
-    cores: 1
-    nworkers: 128
-    memory: "24GB"
+    cores: 30
+    nworkers: 32
+    memory: "8GB"
     queue: "aics_cpu_general"
     walltime: "9-24:00:00"
+    path_python_env: "/home/matheus.viana/anaconda3/envs/cvapipe/bin/python"
 
 mappoints:
     # Number of map points along each principal component

--- a/config.yaml
+++ b/config.yaml
@@ -2,13 +2,13 @@ appName: cvapipe_analysis
 
 project:
     # Sufix to append to local_staging
-    name: "full"
+    name: "test"
 
 resources:
     # In case a (slurm) cluster is available
-    cores: 32
-    nworkers: 12
-    memory: "128GB"
+    cores: 1
+    nworkers: 128
+    memory: "24GB"
     queue: "aics_cpu_general"
     walltime: "9-24:00:00"
 

--- a/cvapipe_analysis/steps/compute_features/compute_features.py
+++ b/cvapipe_analysis/steps/compute_features/compute_features.py
@@ -165,7 +165,7 @@ class ComputeFeatures(Step):
         df_features = pd.DataFrame(df_features)
         df_features.index = df_features.index.rename("CellId")
         
-        log.info("Saving manifest.")
+        log.info(f"Saving manifest of shape {df_features.shape}.")
         
         # Save manifest
         self.manifest = df_features

--- a/cvapipe_analysis/steps/compute_features/compute_features.py
+++ b/cvapipe_analysis/steps/compute_features/compute_features.py
@@ -155,16 +155,16 @@ class ComputeFeatures(Step):
             log.info(error)
 
         log.info("Reading features from JSON files. This might take a while.")
-            
-        df_features = []
+
         N_CORES = len(os.sched_getaffinity(0))
         with concurrent.futures.ProcessPoolExecutor(N_CORES) as executor:
-            df_features.append(
-                tqdm(executor.map(self._load_features_from_json, cell_features_dataset),
+            df_features = list(tqdm(
+                executor.map(self._load_features_from_json, cell_features_dataset),
                      total=len(cell_features_dataset)))
+            
         df_features = pd.DataFrame(df_features)
         df_features.index = df_features.index.rename("CellId")
-
+        
         log.info("Saving manifest.")
         
         # Save manifest

--- a/cvapipe_analysis/steps/compute_features/compute_features.py
+++ b/cvapipe_analysis/steps/compute_features/compute_features.py
@@ -153,6 +153,8 @@ class ComputeFeatures(Step):
 
         for error in errors:
             log.info(error)
+
+        log.info("Reading features from JSON files. This might take a while.")
             
         df_features = []
         N_CORES = len(os.sched_getaffinity(0))
@@ -163,9 +165,13 @@ class ComputeFeatures(Step):
         df_features = pd.DataFrame(df_features)
         df_features.index = df_features.index.rename("CellId")
 
+        log.info("Saving manifest.")
+        
         # Save manifest
         self.manifest = df_features
         manifest_save_path = self.step_local_staging_dir / "manifest.csv"
         self.manifest.to_csv(manifest_save_path)
 
+        log.info("Manifest saved.")
+        
         return manifest_save_path

--- a/cvapipe_analysis/steps/compute_features/compute_features_tools.py
+++ b/cvapipe_analysis/steps/compute_features/compute_features_tools.py
@@ -1,9 +1,12 @@
+import json
+import argparse
 import numpy as np
 from aicsimageio import AICSImage
 from aicsshparam import shtools, shparam
 from skimage import measure as skmeasure
 from skimage import morphology as skmorpho
 
+        
 def cast_features(features):
     
     """
@@ -200,7 +203,8 @@ def get_features(input_image, input_reference_image, compute_shcoeffs=True):
     
     return features
 
-def get_segmentations(folder, path_to_seg, channels):
+
+def get_segmentations(path_seg, channels):
 
     """
     Find the segmentations that should be used for features
@@ -208,7 +212,7 @@ def get_segmentations(folder, path_to_seg, channels):
 
     Parameters
     --------------------
-    path_to_seg: str
+    path_seg: str
         Path to the 4D binary image.
     channels: list of str
         Name of channels of the 4D binary image.
@@ -231,18 +235,18 @@ def get_segmentations(folder, path_to_seg, channels):
     ch_mem = channels.index('membrane_segmentation')
     ch_str = channels.index('struct_segmentation_roof')
     
-    segs = AICSImage(folder/path_to_seg).data.squeeze()
+    segs = AICSImage(path_seg).data.squeeze()
 
     return segs[ch_dna], segs[ch_mem], segs[ch_str]
     
-def get_raws(folder, path_to_raw, channels):
+def get_raws(path_raw, channels):
 
     """
     Find the raw images.
 
     Parameters
     --------------------
-    path_to_seg: str
+    path_raw: str
         Path to the 4D raw image.
     channels: list of str
         Name of channels of the 4D raw image.
@@ -257,7 +261,88 @@ def get_raws(folder, path_to_raw, channels):
     ch_mem = channels.index('membrane')
     ch_str = channels.index('structucture')
     
-    raw = AICSImage(folder/path_to_raw).data.squeeze()
+    raw = AICSImage(path_raw).data.squeeze()
 
     return raw[ch_dna], raw[ch_mem], raw[ch_str]
+
+
+def load_images_and_calculate_features(path_seg, channels, path_output):
     
+    """
+    Load segmentation images, compute features and saves features
+    as a JSON file.
+
+    Parameters
+    --------------------
+    path_seg: Path
+        Path to the 4D binary image.
+    channels: list of str
+        Name of channels of the 4D raw image.
+    path_outout: Path
+        Path to save the features.
+
+    """
+    
+    # Find the correct segmentation for nucleus,
+    # cell and structure
+    seg_dna, seg_mem, seg_str = get_segmentations(
+        path_seg=path_seg,
+        channels=channels
+    )
+
+    # Compute nuclear features
+    features_dna = get_features(
+        input_image=seg_dna, input_reference_image=seg_mem
+    )
+
+    # Compute cell features
+    features_mem = get_features(
+        input_image=seg_mem, input_reference_image=seg_mem
+    )
+
+    # Compute structure features
+    features_str = get_features(
+        input_image=seg_str, input_reference_image=None, compute_shcoeffs=False
+    )
+
+    # Append prefix to features names
+    features_dna = dict(
+        (f"dna_{key}", value) for (key, value) in features_dna.items()
+    )
+    features_mem = dict(
+        (f"mem_{key}", value) for (key, value) in features_mem.items()
+    )
+    features_str = dict(
+        (f"str_{key}", value) for (key, value) in features_str.items()
+    )
+
+    # Concatenate all features for this cell
+    features = features_dna.copy()
+    features.update(features_mem)
+    features.update(features_str)
+
+    # Save to JSON
+    with open(path_output, "w") as f:
+        json.dump(features, f)
+
+    return
+
+
+if __name__ == "__main__":
+    
+    """
+    You can also run feature calculation from a config file.
+    """
+    
+    parser = argparse.ArgumentParser(description='Manage parallel cytoplasm parameterization')
+    parser.add_argument('--config', help='Path to the JSON config file.', required=True)
+    args = vars(parser.parse_args())
+
+    with open(args['config'], 'r') as f:
+        config = json.load(f)
+    
+    load_images_and_calculate_features(
+        path_seg=config['path'],
+        channels=config['channels'],
+        path_output=config['output']
+    )

--- a/cvapipe_analysis/steps/shapemode/shapemode.py
+++ b/cvapipe_analysis/steps/shapemode/shapemode.py
@@ -174,7 +174,7 @@ class Shapemode(Step):
                 df = df,
                 feature_names = features,
                 prefix = prefix,
-                npcs_to_calc = 8,
+                npcs_to_calc = config['pca']['number_of_pcs'],
                 save = dir_pca / f'pca_{prefix}'
             )
 
@@ -198,7 +198,7 @@ class Shapemode(Step):
                 df_filtered, bin_indexes, (bin_centers, pc_std) = digitize_shape_mode(
                     df = df,
                     feature = pc_name,
-                    nbins = 9,
+                    nbins = config['pca']['number_map_points'],
                     filter_based_on = pc_names,
                     save = dir_avgshape / pc_name,
                 )
@@ -236,12 +236,10 @@ class Shapemode(Step):
                     mode = pc_name,
                     save = dir_avgshape,
                     fix_nuclear_position = None if prefix != 'DNA_MEM' else (df_filtered,bin_indexes),
-                    plot_limits = [-150, 150, -80, 80],
+                    plot_limits = config['pca']['plot_limits'],
                 )
 
                 df_shapemode_paths = df_shapemode_paths.append(df_paths, ignore_index=True)
-
-                import pdb; pdb.set_trace()
 
         # Save datafrme with path for meshes and gifs
         dataframe_path = self.step_local_staging_dir / 'shapemode.csv'

--- a/cvapipe_analysis/steps/shapemode/shapemode.py
+++ b/cvapipe_analysis/steps/shapemode/shapemode.py
@@ -7,6 +7,8 @@ from typing import Dict, List, Optional, Union
 from datastep import Step, log_run_params
 
 import pandas as pd
+
+from ...tools import general
 from .outliers import outliers_removal
 from .dim_reduction import pca_analysis
 from .avgshape import digitize_shape_mode
@@ -38,6 +40,9 @@ class Shapemode(Step):
         no_structural_outliers: bool = False,
         **kwargs
     ):
+        
+        # Load configuration file
+        config = general.load_config_file()
         
         # Load feature dataframe
         path_to_metadata_manifest = self.project_local_staging_dir / 'loaddata/manifest.csv'

--- a/cvapipe_analysis/tools/cluster.py
+++ b/cvapipe_analysis/tools/cluster.py
@@ -1,44 +1,73 @@
+import json
 import dask
+import shutil
+import subprocess
+import numpy as np
 from pathlib import Path
 from datetime import datetime
 from dask.distributed import Client
 from dask_jobqueue import SLURMCluster
 
-def get_distributed_executor_address_on_slurm(log, config):
 
-    # Forces a distributed cluster instantiation
-    log_dir_name = datetime.now().isoformat().split(".")[0]
-    log_dir = Path(f".dask_logs/{log_dir_name}").expanduser()
-    log_dir.mkdir(parents=True, exist_ok=True)
+def run_distributed_feature_extraction(df, path_df, data_folder, output_folder, config, log):
 
-    # Configure dask config
-    dask.config.set(
-        {
-            "scheduler.work-stealing": False,
-            "logging.distributed.worker": "info",
+    log.info("Cleaning distribute directory.")
+    
+    try:
+        shutil.rmtree('.distribute')
+    except: pass
+    
+    for folder in ['log','scripts','config']:
+        dir_dist = Path(".distribute") / folder
+        dir_dist.mkdir(parents=True, exist_ok=True)
+
+    nrows = len(df)
+    nworkers = config['resources']['nworkers']
+    
+    df = df.reset_index(drop=False)
+    
+    log.info("Creating config files.")
+    
+    root = Path().absolute()
+    
+    chunk_size = len(df) // nworkers
+    
+    for chunk, df_chunk in df.groupby(np.arange(nrows)//chunk_size):
+
+        id_ini = int(df_chunk.index[0])
+        id_end = int(df_chunk.index[-1])
+        nrows = id_end - id_ini + 1
+        
+        # Script config
+        
+        script_config = {
+            "csv": str(root / path_df),
+            "skip": id_ini,
+            "nrows": nrows,
+            "data_folder": str(root / data_folder),
+            "output": str(root / output_folder)
         }
-    )
+            
+        with open(f".distribute/config/{chunk}.json", "w") as fj:
+            json.dump(script_config, fj, indent=4, sort_keys=True)
+    
+        # Script
 
-    # Create cluster
-    log.info("Creating SLURMCluster")
-    slurm_cluster = SLURMCluster(
-        cores=config["resources"]["cores"],
-        memory=config["resources"]["memory"],
-        queue=config["resources"]["queue"],
-        walltime=config["resources"]["walltime"],
-        local_directory=str(log_dir),
-        log_directory=str(log_dir),
-    )
+        script_name = f".distribute/scripts/{chunk}.script"
+        
+        with open(script_name, "w") as fs:
+            print("#!/bin/bash", file=fs)
+            print(f"#SBATCH --job-name=cvapipe-{chunk}", file=fs)
+            print("#SBATCH --partition aics_cpu_general", file=fs)
+            print(f"#SBATCH --mem-per-cpu {config['resources']['memory']}", file=fs)
+            print(f"#SBATCH --cpus-per-task {config['resources']['cores']}", file=fs)
+            print(f"#SBATCH --output {str(root)}/.distribute/log/{chunk}.out", file=fs)
+            print(f"srun {config['resources']['path_python_env']} {str(root)}/cvapipe_analysis/steps/compute_features/compute_features_tools.py --config {str(root)}/.distribute/config/{chunk}.json", file=fs)
+    
+        log.info(f"Submitting job cvapipe {chunk}...")
 
-    # Spawn workers
-    slurm_cluster.scale(jobs=config["resources"]["nworkers"])
-    log.info("Created SLURMCluster")
-    client = Client(slurm_cluster)
-    print(client.get_versions(check=True))
+        submission = 'sbatch ' + script_name
+        process = subprocess.Popen(submission, stdout=subprocess.PIPE, shell=True)
+        (out, err) = process.communicate()
 
-    # Use the port from the created connector to set executor address
-    distributed_executor_address = slurm_cluster.scheduler_address
-
-    log.info(f"Dask dashboard available at: {slurm_cluster.dashboard_link}")
-
-    return distributed_executor_address
+    return

--- a/cvapipe_analysis/tools/cluster.py
+++ b/cvapipe_analysis/tools/cluster.py
@@ -27,7 +27,7 @@ def get_distributed_executor_address_on_slurm(log, config):
         queue=config["resources"]["queue"],
         walltime=config["resources"]["walltime"],
         local_directory=str(log_dir),
-        log_directory=str(log_dir)
+        log_directory=str(log_dir),
     )
 
     # Spawn workers

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ requirements = [
     "aicsimageio",
     "imgkit==1.0.2",
     "xvfbwrapper==0.2.9",
-    "aicsshparam>=0.1.0",
+    "aicsshparam>=0.1.1",
     "aicscytoparam>=0.1.2",
     "vtk==9.0.1",
     "quilt3",


### PR DESCRIPTION
Because the combination of Dask and Slurm was very unstable, we replaced the parallel computation done by Dask with `srun` and `concurrent`. A dataframe is split into multiple chunks and each chunk is ran by a job on slurm. Each job runs multiple process in parallel using `ProcessPoolExecutor` from `concurrent`.