### PR TITLE
increase precision when encoding path points as strings in pca scanning

### DIFF
--- a/cvapipe_analysis/steps/pca_path_cells/utils.py
+++ b/cvapipe_analysis/steps/pca_path_cells/utils.py
@@ -31,7 +31,7 @@ def find_closest_cells(
     loc_2d = np.expand_dims(location, 0)
     dists = np.squeeze(cdist(df[dist_cols], loc_2d, metric))
     dist_col = f"{metric} distance to location"
-    loc_str = ", ".join([f"{loc:.1f}" for loc in location])
+    loc_str = ", ".join([f"{loc:.3f}" for loc in location])
     df_dists = pd.DataFrame({dist_col: dists, "location": [loc_str] * len(df)})
 
     df_ids_and_dims = df[[id_col, *dist_cols]]


### PR DESCRIPTION
When scanning PCA for most similar cells, at some point path locations get encoded as strings, to be used as indexes in a pd.DataFrame (see [here](https://github.com/AllenCell/cvapipe_analysis/blob/4da3bb7456a403aa9bd6b90090356293f5d77d15/cvapipe_analysis/steps/pca_path_cells/utils.py#L34)). These strings were using a single decimal place, which caused problems when two locations got rounded up to the same. To fix this, I increased the precision to 3 decimal places.
