### PR TITLE
add convenience functionality for distributed mode

### DIFF
--- a/cvapipe_analysis/tools/cluster.py
+++ b/cvapipe_analysis/tools/cluster.py
@@ -23,13 +23,13 @@ class Distributor:
     the local_staging folder is.
     """
 
-    def __init__(self, control, step):
+    def __init__(self, control):
         self.jobs = []
         self.control = control
         self.rel_path_to_python_file = None
         self.stepfolders = ['log', 'dataframes']
         self.nworkers = control.get_distributed_number_of_workers()
-        self.abs_path_to_distribute = control.get_staging() / f".distribute-{step}"
+        self.abs_path_to_distribute = control.get_staging() / f".distribute-{self.step_name}"
         self.abs_path_to_script_as_str = str(self.abs_path_to_distribute / "jobs.sh")
         self.abs_path_jobs_file_as_str = str(self.abs_path_to_distribute / "jobs.txt")
         self.abs_path_to_cvapipe = Path(
@@ -149,35 +149,35 @@ class Distributor:
 
 class FeaturesDistributor(Distributor):
     def __init__(self, control):
-        super().__init__(control, 'computefeatures')
+        super().__init__(control)
         self.rel_path_to_python_file = "cvapipe_analysis/steps/compute_features/compute_features_tools.py"
 
 
 class ParameterizationDistributor(Distributor):
     def __init__(self, control):
-        super().__init__(control, 'parameterization')
+        super().__init__(control)
         self.rel_path_to_python_file = "cvapipe_analysis/steps/parameterization/parameterization_tools.py"
 
 
 class AggregationDistributor(Distributor):
     def __init__(self, control):
-        super().__init__(control, 'aggregation')
+        super().__init__(control)
         self.rel_path_to_python_file = "cvapipe_analysis/steps/aggregation/aggregation_tools.py"
 
 
 class StereotypyDistributor(Distributor):
     def __init__(self, control):
-        super().__init__(control, 'stereotypy')
+        super().__init__(control)
         self.rel_path_to_python_file = "cvapipe_analysis/steps/stereotypy/stereotypy_tools.py"
 
 
 class ConcordanceDistributor(Distributor):
     def __init__(self, control):
-        super().__init__(control, 'concordance')
+        super().__init__(control)
         self.rel_path_to_python_file = "cvapipe_analysis/steps/concordance/concordance_tools.py"
 
 class CorrelationDistributor(Distributor):
     # Requires blocks distribution instead of chunks
     def __init__(self, control):
-        super().__init__(control, 'correlation')
+        super().__init__(control)
         self.rel_path_to_python_file = "cvapipe_analysis/steps/correlation/correlation_tools.py"

--- a/cvapipe_analysis/tools/cluster.py
+++ b/cvapipe_analysis/tools/cluster.py
@@ -23,13 +23,13 @@ class Distributor:
     the local_staging folder is.
     """
 
-    def __init__(self, control):
+    def __init__(self, control, step):
         self.jobs = []
         self.control = control
         self.rel_path_to_python_file = None
         self.stepfolders = ['log', 'dataframes']
         self.nworkers = control.get_distributed_number_of_workers()
-        self.abs_path_to_distribute = control.get_staging() / ".distribute"
+        self.abs_path_to_distribute = control.get_staging() / f".distribute-{step}"
         self.abs_path_to_script_as_str = str(self.abs_path_to_distribute / "jobs.sh")
         self.abs_path_jobs_file_as_str = str(self.abs_path_to_distribute / "jobs.txt")
         self.abs_path_to_cvapipe = Path(
@@ -149,35 +149,35 @@ class Distributor:
 
 class FeaturesDistributor(Distributor):
     def __init__(self, control):
-        super().__init__(control)
+        super().__init__(control, 'computefeatures')
         self.rel_path_to_python_file = "cvapipe_analysis/steps/compute_features/compute_features_tools.py"
 
 
 class ParameterizationDistributor(Distributor):
     def __init__(self, control):
-        super().__init__(control)
+        super().__init__(control, 'parameterization')
         self.rel_path_to_python_file = "cvapipe_analysis/steps/parameterization/parameterization_tools.py"
 
 
 class AggregationDistributor(Distributor):
     def __init__(self, control):
-        super().__init__(control)
+        super().__init__(control, 'aggregation')
         self.rel_path_to_python_file = "cvapipe_analysis/steps/aggregation/aggregation_tools.py"
 
 
 class StereotypyDistributor(Distributor):
     def __init__(self, control):
-        super().__init__(control)
+        super().__init__(control, 'stereotypy')
         self.rel_path_to_python_file = "cvapipe_analysis/steps/stereotypy/stereotypy_tools.py"
 
 
 class ConcordanceDistributor(Distributor):
     def __init__(self, control):
-        super().__init__(control)
+        super().__init__(control, 'concordance')
         self.rel_path_to_python_file = "cvapipe_analysis/steps/concordance/concordance_tools.py"
 
 class CorrelationDistributor(Distributor):
     # Requires blocks distribution instead of chunks
     def __init__(self, control):
-        super().__init__(control)
+        super().__init__(control, 'correlation')
         self.rel_path_to_python_file = "cvapipe_analysis/steps/correlation/correlation_tools.py"

--- a/cvapipe_analysis/tools/io.py
+++ b/cvapipe_analysis/tools/io.py
@@ -1,6 +1,7 @@
 import os
 import vtk
 import errno
+import logging
 import concurrent
 import numpy as np
 import pandas as pd
@@ -14,6 +15,8 @@ from aicsimageio.writers import OmeTiffWriter
 try:
     from aicsfiles import FileManagementSystem
 except: pass
+
+log = logging.getLogger(__name__)
 
 class LocalStagingIO:
     """
@@ -67,11 +70,34 @@ class LocalStagingIO:
     def get_abs_path_to_step_manifest(self, step):
         return self.control.get_staging() / f"{step}/manifest.csv"
 
+    def write_compute_features_manifest_from_distributed_results(self):
+        df = self.load_step_manifest("loaddata")
+        path = self.control.get_staging() / "computefeatures/cell_features"
+        df_results = self.load_results_in_single_dataframe(path=path)
+        df_results = df_results.set_index('CellId')
+
+        if len(df) != len(df_results):
+            df_miss = df.loc[~df.index.isin(df_results.index)]
+            log.info("Missing feature for indices:")
+            for index in df_miss.index:
+                log.info(f"\t{index}")
+            log.info(f"Total of {len(df_miss)} indices.")
+
+        manifest = df.merge(df_results, left_index=True, right_index=True, how="outer")
+        manifest_path = self.get_abs_path_to_step_manifest("computefeatures")
+        manifest.to_csv(manifest_path)
+        return manifest
+
     def load_step_manifest(self, step, clean=False, **kwargs):
-        df = pd.read_csv(
-            self.get_abs_path_to_step_manifest(step),
-            index_col="CellId", low_memory=False, **kwargs
-        )
+
+        if step == 'computefeatures' and not self.get_abs_path_to_step_manifest(step).is_file():
+            df = self.write_compute_features_manifest_from_distributed_results()
+        else:
+            df = pd.read_csv(
+                self.get_abs_path_to_step_manifest(step),
+                index_col="CellId", low_memory=False, **kwargs
+            )
+        
         if clean:
             feats = ['mem_', 'dna_', 'str_'] #TODO: fix the aliases here
             df = df[[c for c in df.columns if not any(s in c for s in feats)]]
@@ -153,11 +179,12 @@ class LocalStagingIO:
             code = code.reshape(1, *code.shape)
         return code
 
-    def load_results_in_single_dataframe(self):
+    def load_results_in_single_dataframe(self, path=None):
         ''' Not sure this function is producing a column named index when
         the concordance results are loaded. Further investigation is needed
         here'''
-        path = self.control.get_staging() / self.subfolder
+        if path is None:
+            path = self.control.get_staging() / self.subfolder
         files = [{"csv": path/f} for f in os.listdir(path)]
         with concurrent.futures.ProcessPoolExecutor(self.control.get_ncores()) as executor:
             df = pd.concat(


### PR DESCRIPTION
This PR has two features: 
- generate `computefeatures` manifest from distributed results (this isn't done automatically right now)
- create .distribute log folders for each step so we can run steps concurrently and debug distributed computations easier 
