### PR TITLE
fix: step name not accessible to distributor class

### DIFF
--- a/cvapipe_analysis/steps/aggregation/aggregation.py
+++ b/cvapipe_analysis/steps/aggregation/aggregation.py
@@ -39,7 +39,7 @@ class Aggregation(Step):
 
             if distribute:
 
-                distributor = cluster.AggregationDistributor(control)
+                distributor = cluster.AggregationDistributor(self, control)
                 distributor.set_data(df_agg)
                 '''Setting chunk size to 1 here so that each job has to generate
                 a single file. Otherwise Slurm crashes for reasons that I don't

--- a/cvapipe_analysis/steps/compute_features/compute_features.py
+++ b/cvapipe_analysis/steps/compute_features/compute_features.py
@@ -34,7 +34,7 @@ class ComputeFeatures(Step):
 
             if distribute:
 
-                distributor = cluster.FeaturesDistributor(control)
+                distributor = cluster.FeaturesDistributor(self, control)
                 distributor.set_data(df)
                 distributor.distribute()
                 log.info(f"Multiple jobs have been launched. Please come back when the calculation is complete.")

--- a/cvapipe_analysis/steps/compute_features/compute_features_tools.py
+++ b/cvapipe_analysis/steps/compute_features/compute_features_tools.py
@@ -64,7 +64,7 @@ class FeatureCalculator(io.DataProducer):
         else:
             features = self.get_basic_features(self.data_aligned[chId])
         if self.control.should_calculate_shcoeffs(alias):
-            coeffs = self.get_coeff_features(self.data_aligned[chId])
+            coeffs = self.get_coeff_features(self.data_aligned[chId], alias)
             features.update(coeffs)
         return features
     
@@ -123,11 +123,11 @@ class FeatureCalculator(io.DataProducer):
                 features[f'roundness_surface_area{suffix}'] = np.nan
         return features
 
-    def get_coeff_features(self, img):
+    def get_coeff_features(self, img, alias):
         (coeffs, _), (_, _, _, transform) = shparam.get_shcoeffs(
             image=img,
             lmax=self.control.get_lmax(),
-            sigma=self.control.get_sigma(),
+            sigma=self.control.get_sigma()[alias],
             alignment_2d=False
         )
         coeffs = dict((f"{k}_lcc", v) for k, v in coeffs.items())

--- a/cvapipe_analysis/steps/compute_features/compute_features_tools.py
+++ b/cvapipe_analysis/steps/compute_features/compute_features_tools.py
@@ -127,7 +127,7 @@ class FeatureCalculator(io.DataProducer):
         (coeffs, _), (_, _, _, transform) = shparam.get_shcoeffs(
             image=img,
             lmax=self.control.get_lmax(),
-            sigma=self.control.get_sigma()[alias],
+            sigma=self.control.get_sigma(alias),
             alignment_2d=False
         )
         coeffs = dict((f"{k}_lcc", v) for k, v in coeffs.items())

--- a/cvapipe_analysis/steps/concordance/concordance.py
+++ b/cvapipe_analysis/steps/concordance/concordance.py
@@ -46,7 +46,7 @@ class Concordance(Step):
 
             if distribute:
 
-                distributor = cluster.ConcordanceDistributor(control)
+                distributor = cluster.ConcordanceDistributor(self, control)
                 distributor.set_data(df_agg)
                 distributor.distribute()
                 log.info(

--- a/cvapipe_analysis/steps/correlation/correlation.py
+++ b/cvapipe_analysis/steps/correlation/correlation.py
@@ -54,7 +54,7 @@ class Correlation(Step):
 
             if distribute:
 
-                distributor = cluster.CorrelationDistributor(control)
+                distributor = cluster.CorrelationDistributor(self, control)
                 distributor.set_data(df_agg)
                 distributor.distribute_by_row()
                 log.info(

--- a/cvapipe_analysis/steps/parameterization/parameterization.py
+++ b/cvapipe_analysis/steps/parameterization/parameterization.py
@@ -34,7 +34,7 @@ class Parameterization(Step):
 
             if distribute:
 
-                distributor = cluster.ParameterizationDistributor(control)
+                distributor = cluster.ParameterizationDistributor(self, control)
                 distributor.set_data(df)
                 distributor.distribute()
                 log.info(f"Multiple jobs have been launched. Please come back when the calculation is complete.")

--- a/cvapipe_analysis/tools/cluster.py
+++ b/cvapipe_analysis/tools/cluster.py
@@ -23,11 +23,10 @@ class Distributor:
     the local_staging folder is.
     """
 
-    def __init__(self, control, rel_path_to_python_file):
+    def __init__(self, step, control):
         self.jobs = []
+        self.step_name = step.step_name
         self.control = control
-        self.rel_path_to_python_file = rel_path_to_python_file
-        self.step_name = self.extract_step_name()
         self.stepfolders = ['log', 'dataframes']
         self.nworkers = control.get_distributed_number_of_workers()
         self.abs_path_to_distribute = control.get_staging() / f".distribute-{self.step_name}"
@@ -35,9 +34,6 @@ class Distributor:
         self.abs_path_jobs_file_as_str = str(self.abs_path_to_distribute / "jobs.txt")
         self.abs_path_to_cvapipe = Path(
             os.path.abspath(cvapipe_analysis.__file__)).parents[1]
-
-    def extract_step_name(self):
-        return Path(self.rel_path_to_python_file).parent.stem.replace("_", "")
 
     def set_data(self, df):
         self.df = df
@@ -152,36 +148,37 @@ class Distributor:
         return
 
 class FeaturesDistributor(Distributor):
-    def __init__(self, control):
-        super().__init__(control,
-                        rel_path_to_python_file="cvapipe_analysis/steps/compute_features/compute_features_tools.py")
+    def __init__(self, step, control):
+        super().__init__(step, control)
+        self.rel_path_to_python_file = "cvapipe_analysis/steps/compute_features/compute_features_tools.py"
 
 
 class ParameterizationDistributor(Distributor):
-    def __init__(self, control):
-        super().__init__(control,
-                        rel_path_to_python_file="cvapipe_analysis/steps/parameterization/parameterization_tools.py")
+    def __init__(self, step, control):
+        super().__init__(step, control)
+        self.rel_path_to_python_file = "cvapipe_analysis/steps/parameterization/parameterization_tools.py"
 
 
 class AggregationDistributor(Distributor):
-    def __init__(self, control):
-        super().__init__(control,
-                         rel_path_to_python_file="cvapipe_analysis/steps/aggregation/aggregation_tools.py")
+    def __init__(self, step, control):
+        super().__init__(step, control)
+        self.rel_path_to_python_file = "cvapipe_analysis/steps/aggregation/aggregation_tools.py"
 
 
 class StereotypyDistributor(Distributor):
-    def __init__(self, control):
-        super().__init__(control, 
-                        rel_path_to_python_file="cvapipe_analysis/steps/stereotypy/stereotypy_tools.py")
+    def __init__(self, step, control):
+        super().__init__(step, control)
+        self.rel_path_to_python_file = "cvapipe_analysis/steps/stereotypy/stereotypy_tools.py"
 
 
 class ConcordanceDistributor(Distributor):
-    def __init__(self, control):
-        super().__init__(control, 
-                        rel_path_to_python_file= "cvapipe_analysis/steps/concordance/concordance_tools.py")
+    def __init__(self, step, control):
+        super().__init__(step, control) 
+        self.rel_path_to_python_file = "cvapipe_analysis/steps/concordance/concordance_tools.py"
+
 
 class CorrelationDistributor(Distributor):
     # Requires blocks distribution instead of chunks
-    def __init__(self, control):
-        super().__init__(control,
-                         rel_path_to_python_file="cvapipe_analysis/steps/correlation/correlation_tools.py")
+    def __init__(self, step, control):
+        super().__init__(step, control)
+        self.rel_path_to_python_file = "cvapipe_analysis/steps/correlation/correlation_tools.py"

--- a/cvapipe_analysis/tools/cluster.py
+++ b/cvapipe_analysis/tools/cluster.py
@@ -37,7 +37,7 @@ class Distributor:
             os.path.abspath(cvapipe_analysis.__file__)).parents[1]
 
     def extract_step_name(self):
-        return self.rel_path_to_python_file.split("/")[-2]
+        return Path(self.rel_path_to_python_file).parent.stem.replace("_", "")
 
     def set_data(self, df):
         self.df = df

--- a/cvapipe_analysis/tools/cluster.py
+++ b/cvapipe_analysis/tools/cluster.py
@@ -23,10 +23,11 @@ class Distributor:
     the local_staging folder is.
     """
 
-    def __init__(self, control):
+    def __init__(self, control, rel_path_to_python_file):
         self.jobs = []
         self.control = control
-        self.rel_path_to_python_file = None
+        self.rel_path_to_python_file = rel_path_to_python_file
+        self.step_name = self.extract_step_name()
         self.stepfolders = ['log', 'dataframes']
         self.nworkers = control.get_distributed_number_of_workers()
         self.abs_path_to_distribute = control.get_staging() / f".distribute-{self.step_name}"
@@ -34,6 +35,9 @@ class Distributor:
         self.abs_path_jobs_file_as_str = str(self.abs_path_to_distribute / "jobs.txt")
         self.abs_path_to_cvapipe = Path(
             os.path.abspath(cvapipe_analysis.__file__)).parents[1]
+
+    def extract_step_name(self):
+        return self.rel_path_to_python_file.split("/")[-2]
 
     def set_data(self, df):
         self.df = df
@@ -149,35 +153,35 @@ class Distributor:
 
 class FeaturesDistributor(Distributor):
     def __init__(self, control):
-        super().__init__(control)
-        self.rel_path_to_python_file = "cvapipe_analysis/steps/compute_features/compute_features_tools.py"
+        super().__init__(control,
+                        rel_path_to_python_file="cvapipe_analysis/steps/compute_features/compute_features_tools.py")
 
 
 class ParameterizationDistributor(Distributor):
     def __init__(self, control):
-        super().__init__(control)
-        self.rel_path_to_python_file = "cvapipe_analysis/steps/parameterization/parameterization_tools.py"
+        super().__init__(control,
+                        rel_path_to_python_file="cvapipe_analysis/steps/parameterization/parameterization_tools.py")
 
 
 class AggregationDistributor(Distributor):
     def __init__(self, control):
-        super().__init__(control)
-        self.rel_path_to_python_file = "cvapipe_analysis/steps/aggregation/aggregation_tools.py"
+        super().__init__(control,
+                         rel_path_to_python_file="cvapipe_analysis/steps/aggregation/aggregation_tools.py")
 
 
 class StereotypyDistributor(Distributor):
     def __init__(self, control):
-        super().__init__(control)
-        self.rel_path_to_python_file = "cvapipe_analysis/steps/stereotypy/stereotypy_tools.py"
+        super().__init__(control, 
+                        rel_path_to_python_file="cvapipe_analysis/steps/stereotypy/stereotypy_tools.py")
 
 
 class ConcordanceDistributor(Distributor):
     def __init__(self, control):
-        super().__init__(control)
-        self.rel_path_to_python_file = "cvapipe_analysis/steps/concordance/concordance_tools.py"
+        super().__init__(control, 
+                        rel_path_to_python_file= "cvapipe_analysis/steps/concordance/concordance_tools.py")
 
 class CorrelationDistributor(Distributor):
     # Requires blocks distribution instead of chunks
     def __init__(self, control):
-        super().__init__(control)
-        self.rel_path_to_python_file = "cvapipe_analysis/steps/correlation/correlation_tools.py"
+        super().__init__(control,
+                         rel_path_to_python_file="cvapipe_analysis/steps/correlation/correlation_tools.py")

--- a/cvapipe_analysis/tools/controller.py
+++ b/cvapipe_analysis/tools/controller.py
@@ -134,8 +134,8 @@ class Controller:
     def get_lmax(self):
         return self.features_section['SHE']['lmax']
 
-    def get_sigma(self):
-        return self.features_section['SHE']['sigma']
+    def get_sigma(self, alias):
+        return self.features_section['SHE']['sigma'][alias]
 
     def get_aliases_for_pca(self):
         return self.space_section['aliases']

--- a/cvapipe_analysis/tools/io.py
+++ b/cvapipe_analysis/tools/io.py
@@ -403,7 +403,7 @@ class DataProducer(LocalStagingIO):
             chn = self.channels.index(self.control.get_channel_from_alias(alias_ref))
             ref = self.data[chn]
             unq = self.control.make_alignment_unique()
-            _, self.angle = shtools.align_image_2d(ref, unq)
+            _, self.angle = shtools.align_image_2d(ref, make_unique=unq)
             self.data_aligned = shtools.apply_image_alignment_2d(self.data, self.angle)
         return
 


### PR DESCRIPTION
turns out `self.step_name` isn't accessible to `Distributor`. instead of hard-coding the step names I made a function that extracts the step name from `rel_path_to_python_file`. due to order of operations, this requires passing the `rel_path_to_python_file` argument to the constructor. let me know what you think