### PR TITLE
Specify pandas version 1.5.3 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ requirements = [
     *step_workflow_requirements,
     # project requires
     "numpy==1.23",
-    "pandas",
+    "pandas==1.5.3",
     "Pillow",
     "matplotlib",
     "seaborn",


### PR DESCRIPTION
## Reason for PR

Fresh installs of the codebase causes failure at `append` usage. For instance,

```python
  File "/cvapipe_analysis/cvapipe_analysis/steps/load_data/load_data_tools.py", line 123, in get_interphase_test_set
    df_test = df_test.append(df_struct.sample(n=n, random_state=666, replace=False))
  File "/opt/conda/envs/cvapipe/lib/python3.8/site-packages/pandas/core/generic.py", line 5989, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'DataFrame' object has no attribute 'append'
```

Pandas version `2.0` and above has [deprecated](https://pandas.pydata.org/docs/whatsnew/v2.0.0.html#removal-of-prior-version-deprecations-changes) `append`. Eventually we will need to convert the syntax and modify parts of the code to work with [`concat`](https://pandas.pydata.org/docs/reference/api/pandas.concat.html).

## Proposed Fix

We define the specific version used in the original development of the codebase `pandas==1.5.3` in the `setup.py`. 

## Tests

The updated code has been tested with the steps outlined in the `README`. All steps ran successfully.
